### PR TITLE
Support JavaScript files

### DIFF
--- a/Commands/Compile.tmCommand
+++ b/Commands/Compile.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby18
+		<string>#!/usr/bin/env ruby18
 
 require "tempfile"
 require ENV["TM_SUPPORT_PATH"] + "/lib/tm/executor"
@@ -16,9 +16,15 @@ TextMate::Executor.make_project_master_current_document
 
 error_fd = nil
 document = File.read(ENV["TM_FILEPATH"])
+language = case ENV["TM_SCOPE"]
+  when /^source\.js/
+    "JavaScript"
+  else
+    "AppleScript"
+  end
 
 Tempfile::open('tm_osacompile') do |tmpfile|
-  TextMate::Executor.run(ENV["TM_OSACOMPILE"] || "osacompile", "-o", tmpfile.path, ENV["TM_FILEPATH"], :create_error_pipe =&gt; true, :verb =&gt; "Compiling", :use_hashbang =&gt; false, :version_args =&gt; ["-o", tmpfile.path, "-e", "nil"]) do |str, type|
+  TextMate::Executor.run(ENV["TM_OSACOMPILE"] || "osacompile", "-l", language, "-o", tmpfile.path, ENV["TM_FILEPATH"], :create_error_pipe =&gt; true, :verb =&gt; "Compiling", :use_hashbang =&gt; false, :version_args =&gt; ["-o", tmpfile.path, "-e", "nil"]) do |str, type|
     error_fd ||= IO.for_fd(ENV["TM_ERROR_FD"].to_i)
     case type
     when :err
@@ -88,7 +94,7 @@ end
 	<key>outputLocation</key>
 	<string>newWindow</string>
 	<key>scope</key>
-	<string>source.applescript</string>
+	<string>source.applescript, source.js</string>
 	<key>semanticClass</key>
 	<string>process.build.applescript</string>
 	<key>uuid</key>

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby18
+		<string>#!/usr/bin/env ruby18
 
 require ENV["TM_SUPPORT_PATH"] + "/lib/tm/executor"
 require ENV["TM_SUPPORT_PATH"] + "/lib/tm/save_current_document"
@@ -15,8 +15,14 @@ TextMate::Executor.make_project_master_current_document
 
 error_fd = nil
 document = File.read(ENV["TM_FILEPATH"])
+language = case ENV["TM_SCOPE"]
+  when /^source\.js/
+    "JavaScript"
+  else
+    "AppleScript"
+  end
 
-TextMate::Executor.run(ENV["TM_OSASCRIPT"] || "osascript", "-ss", ENV["TM_FILEPATH"], :create_error_pipe =&gt; true, :version_args =&gt; ["-e", "\"AppleScript \" &amp; (AppleScript's version as string)"]) do |str, type|
+TextMate::Executor.run(ENV["TM_OSASCRIPT"] || "osascript", "-l", language, "-ss", ENV["TM_FILEPATH"], :create_error_pipe =&gt; true, :version_args =&gt; ["-e", "\"AppleScript \" &amp; (AppleScript's version as string)"]) do |str, type|
   error_fd ||= IO.for_fd(ENV["TM_ERROR_FD"].to_i)
   case type
   when :err
@@ -68,7 +74,7 @@ end
 	<key>outputLocation</key>
 	<string>newWindow</string>
 	<key>scope</key>
-	<string>source.applescript</string>
+	<string>source.applescript, source.js</string>
 	<key>semanticClass</key>
 	<string>process.run.script.applescript</string>
 	<key>uuid</key>

--- a/Syntaxes/AppleScript.tmLanguage
+++ b/Syntaxes/AppleScript.tmLanguage
@@ -8,7 +8,7 @@
 		<string>script editor</string>
 	</array>
 	<key>firstLineMatch</key>
-	<string>^#!.*(osascript)</string>
+	<string>^#!.*(osascript)(?!(?i:javascript)</string>
 	<key>keyEquivalent</key>
 	<string>^~A</string>
 	<key>name</key>


### PR DESCRIPTION
OSAScript supports JavaScript these days.

These changes:
- Ensures that JavaScript files aren’t highlighted as AppleScript due to `osascript` shebang lines.
- Amends the Compile and Run commands to support JavaScript. It
  uses the root scope to determine the language used, then passes that
  language to osacompile(1) and osascript(1), respectively.

I’m not sure that this bundle is the right “place” for these modifications, but it seems more appropriate than the JavaScript bundle, and the changes seem straightforward enough…

One might consider extracting a tiny library for determining the language to specify.

I’m also sure that there’s a way to amend the “Compile in Script Editor” command, but I haven’t figured that out yet.
